### PR TITLE
Correct tab and header bar colored square

### DIFF
--- a/MediterraneanNight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanNight/gtk-3.0/gtk-widgets.css
@@ -59,7 +59,7 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color:transparent;
 }
 
 /***************
@@ -77,22 +77,6 @@ GtkWindow {
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */


### PR DESCRIPTION
This must fix some problems with big bad colored square on header bar and tab  (fix #1)

It also corrects gtk-widgets for others theme.
