### PR TITLE
Fix MediterraneanDarkest theme

### DIFF
--- a/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
@@ -60,6 +60,7 @@
     background-clip: padding-box;
     border-width: 0px;
 
+    background-color: transparent;
 }
 
 /***************
@@ -73,22 +74,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
@@ -2266,7 +2266,7 @@ GtkCalendar.button {
     border-width: 0px;
     padding: 0px;
 
-    color: @theme_base_color;
+    color: @fg_color;
 }
 
 .menuitem GtkCalendar {
@@ -3497,4 +3497,3 @@ GtkProgressBar.osd.progressbar {
                   alpha(black, 0.13)
                   alpha(black, 0.13);
 }
-


### PR DESCRIPTION
The transparent background has already been fixed for the MediterraneanNight theme at https://github.com/rbrito/pkg-mediterranean-gtk-themes/commit/5b1828292338d525e29b6281e40b08067feeef6e but not for the    MediterraneanDarkest one.

The calendar font color has been wrong all the time, I guess. I changed it to @fg_color. I also tried @text_color but it's inconsistent with the other theme colors in the indicator bar/calendar app. Also the darker background in the calendar days doesn't suit the @fg_color well.
