### PR TITLE
Transparent background for all gtk3 widgets

### DIFF
--- a/MediterraneanDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDark/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
@@ -59,13 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
     background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;

--- a/MediterraneanGrayDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanGrayDark/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanLight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanLight/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanLightDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanLightDarkest/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanNight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanNight/gtk-3.0/gtk-widgets.css
@@ -59,7 +59,7 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-    background-color:transparent;
+    background-color: transparent;
 }
 
 /***************

--- a/MediterraneanNightDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanNightDarkest/gtk-3.0/gtk-widgets.css
@@ -59,7 +59,7 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
@@ -77,22 +77,6 @@ GtkWindow {
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanTribute/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTribute/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanTributeBlue/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTributeBlue/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanWhite/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanWhite/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */

--- a/MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
@@ -59,12 +59,16 @@
     background-origin: border-box;
     background-clip: padding-box;
     border-width: 0px;
-
+    background-color: transparent;
 }
 
 /***************
  * Base States *
  ***************/
+
+GtkWindow {
+    color: @theme_fg_color;
+}
 
 .background {
     color: @theme_fg_color;
@@ -73,22 +77,6 @@
 
 .background:backdrop {
 
-}
-/*
-GtkGrid,
-GtkAlignment,
-GtkAspectFrame,
-GtkButtonBox,
-GtkFixed,
-GtkPaned,
-GtkLayout,
-GtkNotebook,
-GtkExpander,
-GtkOverlay,
-GtkBox
-*/
-GtkOrientable {
-    background-color: @theme_bg_color;
 }
 
 /* FIXME: why do we still need this? */


### PR DESCRIPTION
Each gtk3 widget has an transparent background by default now.

The template for the changes is MediterraneanNight/gtk-3.0/gtk-widgets.css

You can see the changes at the nautilus location bar buttons.
I tested it this way and it looks fine now.

Also see pull request https://github.com/rbrito/pkg-mediterranean-gtk-themes/pull/16
