### PR TITLE
Change text color in calendar

### DIFF
--- a/MediterraneanDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDark/gtk-3.0/gtk-widgets.css
@@ -2266,7 +2266,7 @@ GtkCalendar.button {
     border-width: 0px;
     padding: 0px;
 
-    color: @theme_base_color;
+    color: @text_color;
 }
 
 .menuitem GtkCalendar {

--- a/MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
@@ -2266,7 +2266,7 @@ GtkCalendar.button {
     border-width: 0px;
     padding: 0px;
 
-    color: @theme_base_color;
+    color: @text_color;
 }
 
 .menuitem GtkCalendar {

--- a/MediterraneanWhite/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanWhite/gtk-3.0/gtk-widgets.css
@@ -2266,7 +2266,7 @@ GtkCalendar.button {
     border-width: 0px;
     padding: 0px;
 
-    color: @theme_base_color;
+    color: @text_color;
 }
 
 .menuitem GtkCalendar {

--- a/MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
@@ -2266,7 +2266,7 @@ GtkCalendar.button {
     border-width: 0px;
     padding: 0px;
 
-    color: @theme_base_color;
+    color: @text_color;
 }
 
 .menuitem GtkCalendar {


### PR DESCRIPTION
In some cases the text color in the calendar is not visible and
therefore have been changed from @theme_base_color to @text_color. In
the other cases the color @theme_base_color seems to be the right color.

Nevertheless there are still some other problems with the calendar in some themes, like the focus background-color with the current day, which is not handled in this PR.

Also see pull request https://github.com/rbrito/pkg-mediterranean-gtk-themes/pull/16
