### PR TITLE
Clean up

### DIFF
--- a/MediterraneanDark/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanDark/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanDark/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanDark/gtk-3.0/gtk-widgets-assets.css
@@ -233,7 +233,6 @@ GtkScale.scale-has-marks-below.slider.horizontal:insensitive {
     background-image: url("assets/scale-slider-down-insensitive-dark.png");
 }
 
-
 GtkScale.scale-has-marks-below.slider.vertical {
     background-image: url("assets/scale-slider-right-dark.png");
 }

--- a/MediterraneanDark/gtk-3.0/gtk.css
+++ b/MediterraneanDark/gtk-3.0/gtk.css
@@ -6,15 +6,16 @@
 @define-color selected_bg_color #496490;
 @define-color selected_fg_color #ebebeb;
 @define-color tooltip_bg_color #343434;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
-@define-color theme_base_color #2A2A2A;
-@define-color theme_bg_color #383838;
-@define-color theme_text_color #dddddd;
-@define-color theme_fg_color #C0C0C0;
+/* Colormap actually used by the theme, to be overridden in other css files */
+@define-color theme_base_color @base_color;
+@define-color theme_bg_color @bg_color;
+@define-color theme_text_color @text_color;
+@define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#000, 0.22);
-@define-color theme_selected_bg_color #496490;
-@define-color theme_selected_fg_color #EBEBEB;
+@define-color theme_selected_bg_color @selected_bg_color;
+@define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.16);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
 @define-color theme_tooltip_fg_color @tooltip_fg_color;
@@ -26,7 +27,7 @@
 /*************************[Mediterranean-Night]***************************/
 @define-color theme_bg_dark_color #626262;
 @define-color theme_fg_dark_color #e8e8e8;
-@define-color theme_text_dark_color #F5F5F5;
+@define-color theme_text_dark_color #f5f5f5;
 @define-color theme_shadow_dark_color alpha(#000, 0.15);
 @define-color theme_highlight_color alpha(#fff, 0.08);
 @define-color theme_button_border_dark shade(@theme_bg_dark_color, 0.75);
@@ -141,7 +142,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -191,8 +192,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanDark/gtk-3.0/menu.css
+++ b/MediterraneanDark/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanDarkest/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanDarkest/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanDarkest/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanDarkest/gtk-3.0/gtk-widgets-assets.css
@@ -233,7 +233,6 @@ GtkScale.scale-has-marks-below.slider.horizontal:insensitive {
     background-image: url("assets/scale-slider-down-insensitive-dark.png");
 }
 
-
 GtkScale.scale-has-marks-below.slider.vertical {
     background-image: url("assets/scale-slider-right-dark.png");
 }

--- a/MediterraneanDarkest/gtk-3.0/gtk.css
+++ b/MediterraneanDarkest/gtk-3.0/gtk.css
@@ -6,15 +6,15 @@
 @define-color selected_bg_color #496490;
 @define-color selected_fg_color #ebebeb;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
-@define-color theme_base_color #2a2a2a;
-@define-color theme_bg_color #383838;
-@define-color theme_text_color #dddddd;
-@define-color theme_fg_color  #c0c0c0;
+@define-color theme_base_color @base_color;
+@define-color theme_bg_color @bg_color;
+@define-color theme_text_color @text_color;
+@define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#000, 0.22);
-@define-color theme_selected_bg_color #496490;
+@define-color theme_selected_bg_color @selected_bg_color;
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.20);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -25,9 +25,9 @@
 @define-color menu_shadow_color alpha(#fff, 0.20);
 
 /**********************[Mediterranean-Night-Darkest]***********************/
-@define-color theme_bg_dark_color #383838;
-@define-color theme_fg_dark_color #c0c0c0;
-@define-color theme_text_dark_color #dddddd;
+@define-color theme_bg_dark_color @theme_bg_color;
+@define-color theme_fg_dark_color @theme_fg_color;
+@define-color theme_text_dark_color @theme_text_color;
 @define-color theme_shadow_dark_color alpha(#000, 0.30);
 @define-color theme_highlight_color alpha(#fff, 0.05);
 @define-color theme_button_border_dark shade(@theme_bg_dark_color, 0.68);
@@ -143,7 +143,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -193,8 +193,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanDarkest/gtk-3.0/menu.css
+++ b/MediterraneanDarkest/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanGrayDark/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanGrayDark/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanGrayDark/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanGrayDark/gtk-3.0/gtk-widgets-assets.css
@@ -233,7 +233,6 @@ GtkScale.scale-has-marks-below.slider.horizontal:insensitive {
     background-image: url("assets/scale-slider-down-insensitive-dark.png");
 }
 
-
 GtkScale.scale-has-marks-below.slider.vertical {
     background-image: url("assets/scale-slider-right-dark.png");
 }
@@ -257,7 +256,6 @@ GtkSwitch {
 .primary-toolbar.toolbar GtkSwitch.trough,
 GtkSwitch.trough,
 GtkSwitch.trough:backdrop {
-
     border: none;
     border-image: none;
     background: none;

--- a/MediterraneanGrayDark/gtk-3.0/gtk.css
+++ b/MediterraneanGrayDark/gtk-3.0/gtk.css
@@ -133,7 +133,6 @@
 @define-color toolbar_shadow_color @theme_shadow_dark_color;
 @define-color toolbar_border_color @theme_button_border_dark;
 
-
 @define-color nautilus_cluebar_color shade(@sidebar_background, 1.00);
 @define-color treeview_focus_border  @nautilus_cluebar_color;
 

--- a/MediterraneanGrayDark/gtk-3.0/gtk.css
+++ b/MediterraneanGrayDark/gtk-3.0/gtk.css
@@ -6,15 +6,15 @@
 @define-color selected_bg_color #496490;
 @define-color selected_fg_color #ebebeb;
 @define-color tooltip_bg_color #343434;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
-@define-color theme_base_color #2a2a2a;
-@define-color theme_bg_color #383838;
-@define-color theme_text_color #dddddd;
-@define-color theme_fg_color #c0c0c0;
+@define-color theme_base_color @base_color;
+@define-color theme_bg_color @bg_color;
+@define-color theme_text_color @text_color;
+@define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#000, 0.22);
-@define-color theme_selected_bg_color #496490;
+@define-color theme_selected_bg_color @selected_bg_color;
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.20);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -26,7 +26,7 @@
 
 /*************************[Mediterranean-GrayDark]***************************/
 @define-color theme_bg_dark_color #d0d0d0;
-@define-color theme_fg_dark_color #383838;
+@define-color theme_fg_dark_color @theme_bg_color;
 @define-color theme_text_dark_color #303030;
 @define-color theme_shadow_dark_color alpha(#fff, 0.25);
 @define-color theme_highlight_color alpha(#fff, 0.22);
@@ -144,7 +144,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -194,8 +194,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@theme_bg_color, 1.1);
 @define-color wm_bg_b @theme_bg_color;

--- a/MediterraneanGrayDark/gtk-3.0/menu.css
+++ b/MediterraneanGrayDark/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanGrayDark/gtk-3.0/scrollbar.css
+++ b/MediterraneanGrayDark/gtk-3.0/scrollbar.css
@@ -55,7 +55,7 @@
 
 .scrollbar.slider.vertical:prelight {
 	background-color:         alpha (#eee, 0.42);
-	border-color: @theme_base_color;
+	border-color: @base_color;
     background-image: -gtk-gradient (linear, left top, right top,
                                      from (shade(@theme_fg_color, 0.90)),
                                      to   (shade(@theme_fg_color, 0.55)));
@@ -63,7 +63,7 @@
 
 .scrollbar.slider.horizontal:prelight {
 	background-color:         alpha (#eee, 0.42);
-	border-color: @theme_base_color;
+	border-color: @base_color;
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade(@theme_fg_color, 0.90)),
                                      to   (shade(@theme_fg_color, 0.55)));

--- a/MediterraneanLight/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanLight/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanLight/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanLight/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanLight/gtk-3.0/gtk.css
+++ b/MediterraneanLight/gtk-3.0/gtk.css
@@ -34,10 +34,8 @@
 @define-color theme_entry_border_dark @theme_button_border_dark;
 @define-color theme_path_bg_color shade(@theme_bg_dark_color, 0.90);
 @define-color theme_path_active_color shade(@theme_bg_dark_color, 0.78);
-
 @define-color theme_tab_dark_active1 shade(@theme_bg_dark_color, 0.75);
 @define-color theme_tab_dark_active2 shade(@theme_tab_dark_active1, 1.45);
-
 @define-color theme_mdi_border_color shade(@theme_bg_dark_color, 0.75);
 
 @define-color menu_bg_dark_color shade(@theme_bg_dark_color, 0.88);

--- a/MediterraneanLight/gtk-3.0/gtk.css
+++ b/MediterraneanLight/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #282828;
 @define-color fg_color #323232;
 @define-color selected_bg_color #4D6E92;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -14,7 +14,7 @@
 @define-color theme_text_color @text_color;
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.22);
-@define-color theme_selected_bg_color shade(#4D6E92, 1.00);
+@define-color theme_selected_bg_color shade(@selected_bg_color, 1.00);
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.18);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -144,7 +144,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -194,8 +194,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanLight/gtk-3.0/menu.css
+++ b/MediterraneanLight/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanLightDarkest/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanLightDarkest/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanLightDarkest/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanLightDarkest/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanLightDarkest/gtk-3.0/gtk.css
+++ b/MediterraneanLightDarkest/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #282828;
 @define-color fg_color #323232;
 @define-color selected_bg_color #4D6E92;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -14,7 +14,7 @@
 @define-color theme_text_color @text_color;
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.22);
-@define-color theme_selected_bg_color shade(#4D6E92, 1.00);
+@define-color theme_selected_bg_color shade(@selected_bg_color, 1.00);
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.12);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -144,7 +144,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -194,8 +194,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanLightDarkest/gtk-3.0/gtk.css
+++ b/MediterraneanLightDarkest/gtk-3.0/gtk.css
@@ -131,7 +131,6 @@
 @define-color toolbar_fg_color shade(@theme_fg_dark_color, 1.00);
 @define-color toolbar_shadow_color @theme_shadow_dark_color;
 @define-color toolbar_border_color @theme_button_border_dark;
-
 @define-color toolbar_active_button_color #909081;
 
 @define-color nautilus_cluebar_color shade(@sidebar_background, 1.00);

--- a/MediterraneanLightDarkest/gtk-3.0/menu.css
+++ b/MediterraneanLightDarkest/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanNight/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanNight/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanNight/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanNight/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/
@@ -237,7 +236,6 @@ GtkSwitch {
     border-radius: 8px;
     padding: 0;
 }
-
 
 .menu GtkSwitch.trough,
 .toolbar.menubar GtkSwitch.trough,

--- a/MediterraneanNight/gtk-3.0/gtk.css
+++ b/MediterraneanNight/gtk-3.0/gtk.css
@@ -131,7 +131,6 @@
 @define-color toolbar_fg_color shade(@theme_fg_dark_color, 1.00);
 @define-color toolbar_shadow_color @theme_shadow_dark_color;
 @define-color toolbar_border_color @theme_button_border_dark;
-
 @define-color toolbar_active_button_color #909081;
 
 @define-color nautilus_cluebar_color shade(@sidebar_background, 1.00);

--- a/MediterraneanNight/gtk-3.0/gtk.css
+++ b/MediterraneanNight/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #161616;
 @define-color fg_color #242424;
 @define-color selected_bg_color #4a6787;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -144,7 +144,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -194,8 +194,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanNightDarkest/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanNightDarkest/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanNightDarkest/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanNightDarkest/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanNightDarkest/gtk-3.0/gtk.css
+++ b/MediterraneanNightDarkest/gtk-3.0/gtk.css
@@ -131,7 +131,6 @@
 @define-color toolbar_fg_color shade(@theme_fg_dark_color, 1.00);
 @define-color toolbar_shadow_color @theme_shadow_dark_color;
 @define-color toolbar_border_color @theme_button_border_dark;
-
 @define-color toolbar_active_button_color #909081;
 
 @define-color nautilus_cluebar_color shade(@sidebar_background, 1.00);

--- a/MediterraneanNightDarkest/gtk-3.0/gtk.css
+++ b/MediterraneanNightDarkest/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #161616;
 @define-color fg_color #242424;
 @define-color selected_bg_color #4a6787;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -14,7 +14,7 @@
 @define-color theme_text_color @text_color;
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.15);
-@define-color theme_selected_bg_color  #4a6787;
+@define-color theme_selected_bg_color @selected_bg_color;
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.18);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -144,7 +144,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -194,8 +194,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanNightDarkest/gtk-3.0/menu.css
+++ b/MediterraneanNightDarkest/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanTribute/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanTribute/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanTribute/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanTribute/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanTribute/gtk-3.0/gtk.css
+++ b/MediterraneanTribute/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #282828;
 @define-color fg_color #363636;
 @define-color selected_bg_color #507fc5;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #343434;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -15,7 +15,7 @@
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.22);
 /* @define-color theme_selected_bg_color #f5d168; */
-@define-color theme_selected_bg_color #507fc5;
+@define-color theme_selected_bg_color @selected_bg_color;
 @define-color theme_selected_fg_color #fbfbfb;
 @define-color theme_selected_shadow_color alpha(#000, 0.15);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -27,8 +27,8 @@
 
 /**************************[Mediterranean-Tribute]***************************/
 @define-color theme_bg_dark_color #ceac74;
-@define-color theme_fg_dark_color #363636;
-@define-color theme_text_dark_color #282828;
+@define-color theme_fg_dark_color @theme_fg_color;
+@define-color theme_text_dark_color @theme_text_color;
 @define-color theme_shadow_dark_color alpha(#fff, 0.16);
 @define-color theme_highlight_color alpha(#fff, 0.15);
 @define-color theme_button_border_dark shade(@theme_bg_dark_color, 0.75);
@@ -146,7 +146,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -196,8 +196,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanTribute/gtk-3.0/gtk.css
+++ b/MediterraneanTribute/gtk-3.0/gtk.css
@@ -133,10 +133,7 @@
 @define-color toolbar_fg_color shade(@theme_fg_dark_color, 1.00);
 @define-color toolbar_shadow_color @theme_shadow_dark_color;
 @define-color toolbar_border_color @theme_button_border_dark;
-
 @define-color toolbar_active_button_color #909081;
-
-
 
 @define-color nautilus_cluebar_color shade(@sidebar_background, 1.00);
 @define-color treeview_focus_border  @nautilus_cluebar_color;

--- a/MediterraneanTribute/gtk-3.0/menu.css
+++ b/MediterraneanTribute/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanTributeBlue/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanTributeBlue/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanTributeBlue/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanTributeBlue/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanTributeBlue/gtk-3.0/gtk.css
+++ b/MediterraneanTributeBlue/gtk-3.0/gtk.css
@@ -135,10 +135,7 @@
 @define-color toolbar_fg_color shade(@theme_fg_dark_color, 1.00);
 @define-color toolbar_shadow_color @theme_shadow_dark_color;
 @define-color toolbar_border_color @theme_button_border_dark;
-
 @define-color toolbar_active_button_color #909081;
-
-
 
 @define-color nautilus_cluebar_color shade(@sidebar_background, 1.00);
 @define-color treeview_focus_border  @nautilus_cluebar_color;

--- a/MediterraneanTributeBlue/gtk-3.0/gtk.css
+++ b/MediterraneanTributeBlue/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #282828;
 @define-color fg_color #363636;
 @define-color selected_bg_color #2e91be;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #343434;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -14,7 +14,7 @@
 @define-color theme_text_color @text_color;
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.22);
-@define-color theme_selected_bg_color #2e91be;
+@define-color theme_selected_bg_color @selected_bg_color;
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.12);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -148,7 +148,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -198,8 +198,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanTributeBlue/gtk-3.0/menu.css
+++ b/MediterraneanTributeBlue/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanTributeDark/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanTributeDark/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanTributeDark/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanTributeDark/gtk-3.0/gtk-widgets-assets.css
@@ -233,7 +233,6 @@ GtkScale.scale-has-marks-below.slider.horizontal:insensitive {
     background-image: url("assets/scale-slider-down-insensitive-dark.png");
 }
 
-
 GtkScale.scale-has-marks-below.slider.vertical {
     background-image: url("assets/scale-slider-right-dark.png");
 }

--- a/MediterraneanTributeDark/gtk-3.0/gtk.css
+++ b/MediterraneanTributeDark/gtk-3.0/gtk.css
@@ -6,7 +6,7 @@
 @define-color selected_bg_color #496490;
 @define-color selected_fg_color #f3f3f3;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -16,7 +16,7 @@
 @define-color theme_shadow_color alpha(#000, 0.23);
 /* @define-color theme_selected_bg_color mix(shade(#f3bb53, 0.70), @theme_bg_color, 0.20); */
 /*@define-color theme_selected_bg_color shade(#dc8d1b, 0.80);*/
-@define-color theme_selected_bg_color #496490;
+@define-color theme_selected_bg_color @selected_bg_color;
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.16);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -147,7 +147,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -197,8 +197,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanTributeDark/gtk-3.0/menu.css
+++ b/MediterraneanTributeDark/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanTributeDark/gtk-3.0/settings.ini
+++ b/MediterraneanTributeDark/gtk-3.0/settings.ini
@@ -1,3 +1,4 @@
 [Settings]
 gtk-color-scheme = "base_color:#2a2a2a\nbg_color:#383838\ntooltip_bg_color:#343434\nselected_bg_color:#496490\ntext_color:#d4d4d4\nfg_color:#bababa\ntooltip_fg_color:#ffffff\nselected_fg_color:#f3f3f3\nlink_color:#4a90d9\nbg_color_dark:#383838\nfg_color_dark:#dddddd"
 gtk-auto-mnemonics = 1
+gtk-visible-focus = automatic

--- a/MediterraneanWhite/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanWhite/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanWhite/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanWhite/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanWhite/gtk-3.0/gtk.css
+++ b/MediterraneanWhite/gtk-3.0/gtk.css
@@ -4,9 +4,9 @@
 @define-color text_color #282828;
 @define-color fg_color #363636;
 @define-color selected_bg_color #4a75b8;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -14,7 +14,7 @@
 @define-color theme_text_color @text_color;
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.24);
-@define-color theme_selected_bg_color shade(#4a75b8, 1.00);
+@define-color theme_selected_bg_color shade(@selected_bg_color, 1.00);
 /* @define-color theme_selected_bg_color shade(#3c81de, 0.90); */
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.18);
@@ -26,9 +26,9 @@
 @define-color menu_shadow_color @theme_shadow_color;
 
 /**************************[Mediterranean-White]***************************/
-@define-color theme_bg_dark_color#E9E9E9;
-@define-color theme_fg_dark_color #363636;
-@define-color theme_text_dark_color #282828;
+@define-color theme_bg_dark_color @theme_bg_color;
+@define-color theme_fg_dark_color @theme_fg_color;
+@define-color theme_text_dark_color @theme_text_color;
 @define-color theme_shadow_dark_color alpha(#fff, 0.22);
 @define-color theme_highlight_color alpha(#fff, 0.26);
 @define-color theme_button_border_dark shade(@theme_bg_dark_color, 0.75);
@@ -147,7 +147,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -197,8 +197,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanWhite/gtk-3.0/menu.css
+++ b/MediterraneanWhite/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,

--- a/MediterraneanWhiteNight/gtk-3.0/gnome-mdi.css
+++ b/MediterraneanWhiteNight/gtk-3.0/gnome-mdi.css
@@ -1,5 +1,3 @@
-
-
 /*
 GeditWindow GtkLayout,
 GeditWindow GtkExpander,

--- a/MediterraneanWhiteNight/gtk-3.0/gtk-widgets-assets.css
+++ b/MediterraneanWhiteNight/gtk-3.0/gtk-widgets-assets.css
@@ -228,7 +228,6 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
 
-
 /**********
  * switch *
  **********/

--- a/MediterraneanWhiteNight/gtk-3.0/gtk.css
+++ b/MediterraneanWhiteNight/gtk-3.0/gtk.css
@@ -1,12 +1,12 @@
 /* Default color scheme */
-@define-color base_color #DADADA;
-@define-color bg_color #C6C6C6;
+@define-color base_color #dadada;
+@define-color bg_color #c6c6c6;
 @define-color text_color #161616;
 @define-color fg_color #242424;
 @define-color selected_bg_color #4a6787;
-@define-color selected_fg_color #ffffff;
+@define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #040404;
-@define-color tooltip_fg_color #ffffff;
+@define-color tooltip_fg_color #fff;
 
 /* Colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_base_color @base_color;
@@ -14,7 +14,7 @@
 @define-color theme_text_color @text_color;
 @define-color theme_fg_color @fg_color;
 @define-color theme_shadow_color alpha(#fff, 0.22);
-@define-color theme_selected_bg_color  #646464;
+@define-color theme_selected_bg_color #646464;
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_selected_shadow_color alpha(#000, 0.18);
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
@@ -25,10 +25,10 @@
 @define-color menu_shadow_color @theme_shadow_color;
 
 /*************************[Mediterranean-White-Night]***************************/
-@define-color theme_bg_dark_color #C6C6C6;
-@define-color theme_fg_dark_color #242424;
-@define-color theme_text_dark_color #161616;
-@define-color theme_shadow_dark_color alpha(#fff, 0.22);
+@define-color theme_bg_dark_color @theme_bg_color;
+@define-color theme_fg_dark_color @theme_fg_color;
+@define-color theme_text_dark_color @theme_text_color;
+@define-color theme_shadow_dark_color @theme_shadow_color;
 @define-color theme_highlight_color alpha(#fff, 0.18);
 @define-color theme_button_border_dark shade(@theme_bg_dark_color, 0.74);
 @define-color theme_entry_border_dark @theme_button_border_dark;
@@ -146,7 +146,7 @@
 /*******
  * OSD *
  *******/
-@define-color osd_highlight #ffffff;
+@define-color osd_highlight #fff;
 @define-color osd_lowlight #525252;
 @define-color osd_base #212526;
 
@@ -196,8 +196,8 @@
 @define-color osd_trough_bg alpha(@osd_button_fg, 0.10);
 
 /* Metacity ¡No modificar! */
-@define-color wm_highlight #ffffff;
-@define-color wm_title_highlight #ffffff;
+@define-color wm_highlight #fff;
+@define-color wm_title_highlight #fff;
 
 @define-color wm_bg_a shade (@bg_color, 1.1);
 @define-color wm_bg_b @bg_color;

--- a/MediterraneanWhiteNight/gtk-3.0/menu.css
+++ b/MediterraneanWhiteNight/gtk-3.0/menu.css
@@ -232,6 +232,7 @@ GtkTreeMenu .menuitem *:prelight,
 	/* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
+    background-color: transparent;
 }
 
 .menuitem.check,


### PR DESCRIPTION
See commit messages :wink:

I also changed color values from #ffffff to #fff (there where no #000000). This has no effect at all, it's just shorter.

There is also the possibility to change these values to black and white. This seems to be build-in variables.
Both, #000 and black or #fff and white are used in the css files. So there is no consistency here. I can't tell if we would benefit if we use the color codes or the color names but we should choose one option.

A single command like:

```
find . -name "*.css" -exec sed -i "s/#000/black/g" {} \;
# and
find . -name "*.css" -exec sed -i "s/#fff/white/g" {} \;
```

would do the job. Black and white don't need an @ tag as far as I know.
