### PR TITLE
Add missing header bars and CSD

### DIFF
--- a/MediterraneanDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDark/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanDarkest/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanGrayDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanGrayDark/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanLight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanLight/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanLightDarkest/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanLightDarkest/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanTribute/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTribute/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanTributeBlue/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTributeBlue/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanWhite/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanWhite/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
+++ b/MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
@@ -179,6 +179,153 @@ GtkLabel:insensitive {
     border-radius: 2px;
 }
 
+/***************
+ * Header bars *
+ ***************/
+.header-bar {
+    border-width: 0 0 1px;
+    border-style: solid;
+    border-color: shade(@borders, 0.90);
+    border-radius: 15px 15px 0px 0px;
+    box-shadow: inset 0 -1px shade(@borders, 1.30);
+    background-color: @theme_bg_dark_color;
+
+    padding: 6px 6px 5px 6px;
+}
+
+.header-bar:backdrop {
+    border-image: linear-gradient(to top,
+                                  @unfocused_borders,
+                                  @unfocused_borders 1px,
+                                  @theme_unfocused_bg_color 1px) 0 0 2;
+    box-shadow: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.header-bar .button.text-button {
+    padding: 2px 16px;
+}
+
+.header-bar .button.image-button {
+    padding: 5px 4px 5px 5px;
+}
+
+.header-bar .title {
+    font: Bold 11;
+    color: @theme_text_dark_color;
+
+}
+
+.header-bar .subtitle {
+    font: 9;
+    color: @theme_text_dark_color;
+
+}
+.header-bar GtkSeparatorToolItem,
+.header-bar .separator,
+.header-bar .separator:insensitive,
+.header-bar .pane-separator
+ {
+    border-color: 		 alpha (#000, 0.24);
+    border-bottom-color: alpha (#000, 0.08);
+    border-right-color:  alpha (#000, 0.08);
+}
+/*******
+ * CSD *
+ *******/
+.titlebar {
+    text-shadow: 0 1px @wm_title_shadow;
+
+
+    border-radius: 7px 7px 0px 0px;
+}
+
+/* this is the default titlebar that is added by GTK
+ * when client-side decorations are in use and the application
+ * did not set a custom titlebar.
+ */
+.titlebar.default-decoration {
+    border: none;
+    box-shadow: none;
+}
+
+.titlebar .title {
+    font: Bold 11;
+}
+
+.titlebar:backdrop {
+    text-shadow: none;
+    background-image: none;
+    background-color: @theme_bg_dark_color;
+}
+
+.titlebar .titlebutton {
+    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    color: @wm_title;
+    background: none;
+    padding: 5px 5px 6px 5px;
+
+    border-radius: 3px;
+    border-width: 1px 1px 2px 1px;
+    border-color: transparent;
+    border-style: solid;
+    border-image: none;
+}
+
+.titlebar .titlebutton:hover {
+    background-image: linear-gradient(to bottom,
+                                      @button_hover_gradient_color_a,
+                                      @button_hover_gradient_color_b);
+}
+
+.titlebar .titlebutton:active {
+    background-image: linear-gradient(to bottom,
+                                      @borders,
+                                      shade(@theme_bg_dark_color, 0.95)
+                                      );
+    color: @theme_selected_fg_color;
+    icon-shadow: none;
+}
+
+.titlebar .right .titlebutton:first-child {
+    border-left: 1px solid @menu_separator;
+}
+
+.titlebar .right .titlebutton:last-child {
+
+}
+
+.titlebar .left .titlebutton:last-child {
+    border-right: 1px solid @menu_separator;
+}
+
+.titlebar .left .titlebutton:first-child {
+
+}
+
+.titlebar .titlebutton:backdrop {
+    background-image: none;
+    color: @wm_unfocused_dark_title;
+    border-image: none;
+    icon-shadow: none;
+}
+
+.window-frame {
+    border-color: darker(@theme_bg_dark_color);
+    border-radius: 7px 7px 0 0;
+    border-width: 1px;
+    border-style: solid;
+
+    box-shadow: 0 2px 8px 3px @theme_shadow_dark_color;
+
+    /* this is used for the resize cursor area */
+    margin: 10px;
+}
+
+.window-frame:backdrop {
+    box-shadow: 0 2px 5px 1px @theme_shadow_dark_color;
+}
+
 /*************
  * separator *
  *************/

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,159 @@
+diff --git a/MediterraneanNight/gtk-2.0/apps/panel.rc b/MediterraneanNight/gtk-2.0/apps/panel.rc
+index fd23793..8286a6a 100644
+--- a/MediterraneanNight/gtk-2.0/apps/panel.rc
++++ b/MediterraneanNight/gtk-2.0/apps/panel.rc
+@@ -1,12 +1,53 @@
++style "murrine-dark" {
++      # Stolen from https://bbs.archlinux.org/viewtopic.php?pid=1026506#p1026506
++      # I (rbrito) made the following substitutions:
++      # @text_color_dark with @theme_text_dark_color
++      # @bg_color_dark with @theme_bg_dark_color
++      base[NORMAL]		= @theme_bg_dark_color
++      base[PRELIGHT]		= shade (0.95, @theme_bg_dark_color)
++      base[INSENSITIVE]		= @theme_bg_dark_color
++      bg[NORMAL]		= @theme_bg_dark_color
++      bg[PRELIGHT]		= shade (1.02, @theme_bg_dark_color)
++      bg[SELECTED]		= shade (0.90, @selected_bg_color)
++      bg[INSENSITIVE]		= @theme_bg_dark_color
++      bg[ACTIVE]		= shade (1.04, @theme_bg_dark_color)
++      fg[NORMAL]		= @theme_text_dark_color
++      fg[PRELIGHT]		= @theme_text_dark_color
++      fg[SELECTED]		= @theme_text_dark_color
++      fg[ACTIVE]		= @theme_text_dark_color
++      fg[INSENSITIVE]		= darker (@bg_color)
++      text[NORMAL]		= @theme_text_dark_color
++      text[PRELIGHT]		= @theme_text_dark_color
++      text[ACTIVE]		= @theme_text_dark_color
++      text[SELECTED]		= @theme_text_dark_color
++      text[INSENSITIVE]		= darker (@theme_bg_dark_color)
++}
++
++# Stolen from: https://forum.xfce.org/viewtopic.php?pid=28950#p28950
++# I (rbrito) made the following substitutions:
++# @text_color_dark with @theme_text_dark_color
++# @bg_color_dark with @theme_bg_dark_color
++style "murrine-wide-dark"    = "murrine-dark"    {
++      xthickness = 2 ythickness = 2
++}
++
++style "murrine-menubar" = "murrine-dark" {
++    ythickness    = 0
++    bg[NORMAL]    = @bg_color
++    fg[NORMAL]    = @fg_color
++    fg[PRELIGHT]    = @fg_color
++    fg[SELECTED]    = @fg_color
++}
++
+ style "theme-panel" = "murrine-dark"
+ {
+ 	xthickness	= 0
+ 	ythickness	= 0
+ 
+-	bg[NORMAL]	= shade (0.7, @bg_color_dark)
+-	bg[ACTIVE]	= shade (0.5, @bg_color_dark)
+-	bg[PRELIGHT]	= shade (0.35, @bg_color_dark)
+-	bg[SELECTED]	= shade (0.5, @bg_color_dark)
++	bg[NORMAL]	= shade (0.7, @theme_bg_dark_color)
++	bg[ACTIVE]	= shade (0.5, @theme_bg_dark_color)
++	bg[PRELIGHT]	= shade (0.35, @theme_bg_dark_color)
++	bg[SELECTED]	= shade (0.5, @theme_bg_dark_color)
+ 
+ 	fg[NORMAL]	= shade (0.9, @base_color)
+ 	fg[PRELIGHT]	= @base_color
+@@ -42,6 +83,10 @@ style "theme-panel-text"
+ 
+ style "panel-entry" = "murrine-dark"
+ {
++        bg[SELECTED]	= shade(1.1, @selected_bg_color)
++        bg[ACTIVE]	= shade(1.1, @selected_bg_color)
++        bg[NORMAL]	= shade(1.1, @selected_bg_color)
++
+ 	fg[NORMAL]	= @text_color
+ 	fg[PRELIGHT]	= @text_color
+ 	fg[ACTIVE]	= @text_color
+@@ -93,9 +138,9 @@ class "*Xfce*Panel*"                style "theme-panel"
+ widget "*WnckPager*"	    	    style "workspace-switcher"
+ 
+ # Fix gtk-entries in the panel
+-class "GtkEntry"		    style "murrine-combo"
+-class "*SexyIconEntry*"		    style:highest "murrine-combo"	# fixes dict-plugin
+-widget "*xfce4-verve-plugin*GtkEntry"	style:highest "murrine-combo"	# fixes verve-plugin
++class "GtkEntry"		    style "entry"
++class "*SexyIconEntry*"		    style:highest "entry"	# fixes dict-plugin
++widget "*xfce4-verve-plugin*GtkEntry"	style:highest "entry"	# fixes verve-plugin
+ 
+ # Make sure panel text color doesn't change
+ widget_class "*Panel*MenuBar*"      style "theme-main-menu-text"
+@@ -104,12 +149,12 @@ widget "*.clock-applet-button.*"    style "theme-panel-text"
+ widget "*PanelApplet*"              style "theme-panel-text"
+ 
+ # dark menus
+-widget_class "*<GtkMenu>*"              	style "murrine-dark"
++widget_class "*<GtkMenu>*"              	style "theme-main-menu-text"
+ widget_class "*<GtkMenuItem>*"          	style "murrine-wide-dark"
+ widget_class "*<GtkMenuItem>.*.<GtkCalendar>"	style "murrine-dark"
+ widget_class "*<GtkMenuItem>.*.<GtkEntry>"	style "panel-entry"
+-widget_class "*<GtkMenuItem>.*.<GtkScale>" 	style "murrine-scale-dark"
+-widget_class "*<GtkMenuBar>*"           	style "murrine-menubar"
++widget_class "*<GtkMenuItem>.*.<GtkScale>" 	style "murrine-dark"
++widget_class "*<GtkMenuBar>*"           	style "theme-main-menu-text"
+ widget "*.gtk-combobox-popup-menu.*"   		style "murrine-wide-dark"
+ 
+ # dark bg and black text for gdm's panel
+diff --git a/MediterraneanNight/gtk-2.0/apps/terminal.rc b/MediterraneanNight/gtk-2.0/apps/terminal.rc
+index aa48c5f..bbf34be 100644
+--- a/MediterraneanNight/gtk-2.0/apps/terminal.rc
++++ b/MediterraneanNight/gtk-2.0/apps/terminal.rc
+@@ -13,28 +13,14 @@ style "terminal-scrollbar" = "scrollbar"
+ 
+ }
+ 
++# SELECTED means the "current" widget; ACTIVE means at the moment of click
++
+ style "terminal-notebook"
+ {
+-	bg[NORMAL]		= shade( 0.85, @sidebar_background)
+-	bg[ACTIVE]		= shade( 0.70, @sidebar_background)
++	bg[NORMAL]	= shade(1.1, @bg_color)
++	bg[ACTIVE]	= shade(0.875, @bg_color)
+ 	fg[NORMAL] 	= shade(0.80, @text_color) # text selected tab
+ 	fg[ACTIVE] 	= shade(0.28, @sidebar_background)	# text unselected tab
+-
+-	engine "murrine"
+-	{
+-		gradient_shades		= {1.00,0.96,0.92,0.88}
+-		highlight_shade     = 1.03
+-		roundness       	= 0
+-		contrast        	= 0.0	
+-		
+-		## things that don't work:
+-		#glow_shade	= 0.8
+-		#glowstyle           = 2
+-		#focusstyle	    = 3
+-		#glazestyle          = 3
+-		#border_shades	= { 0.45, 2.5 }
+-		#prelight_shade	= 1.5
+-	}
+ }
+ 
+ style "notebook-button" {
+@@ -42,8 +28,7 @@ style "notebook-button" {
+     ythickness		= 0
+     bg[ACTIVE]		= shade (0.68, @sidebar_background)
+     bg[PRELIGHT]        = shade (0.75, @sidebar_background)
+-	engine "murrine"
+-	{
++    engine "murrine" {
+ 	gradient_shades		= {1.00,1.00,1.00,1.00}
+ 	contrast        	= 0.6
+ 	roundness       	= 0
+diff --git a/MediterraneanNight/gtk-2.0/gtkrc b/MediterraneanNight/gtk-2.0/gtkrc
+index d72350e..0d17b00 100644
+--- a/MediterraneanNight/gtk-2.0/gtkrc
++++ b/MediterraneanNight/gtk-2.0/gtkrc
+@@ -1046,4 +1046,4 @@ widget_class "*XfdesktopIconView*" style "xfdesktop-icon-view"
+ include "apps/thunar.rc"		# thunar especific
+ include "apps/terminal.rc"
+ include "apps/gmusicbrowser.rc"
+-
++include "apps/panel.rc"


### PR DESCRIPTION
Copied the header bars and CSD stuff from the MediterraneanNight theme
to all other themes.

See: https://github.com/rbrito/pkg-mediterranean-gtk-themes/issues/26

This doesn't close https://github.com/rbrito/pkg-mediterranean-gtk-themes/issues/26 but fixes all differences in the gtk-3.0 themes. I will add the missing changes which has to be done for gtk-2.0 to the corresponding issue.

Nevertheless... I still have some concerns about the added stuff. Variables like unfocused_borders, button_hover_gradient_color_a and some more aren't defined anywhere in the collection... So, is this a problem? If so, we have to define it in **every** theme (including MediterraneanNight).

I also **didn't test** it because I have no idea what these changes do or which parts of a window are effected :smile_cat:.

BTW: The result of comparing all gtk-widgets.css files:

```
find . -name "gtk-widgets.css" -exec echo {} \; -exec diff MediterraneanNight/gtk-3.0/gtk-widgets.css {} \;

./MediterraneanLightDarkest/gtk-3.0/gtk-widgets.css
./MediterraneanGrayDark/gtk-3.0/gtk-widgets.css
./MediterraneanTribute/gtk-3.0/gtk-widgets.css
./MediterraneanTributeDark/gtk-3.0/gtk-widgets.css
2404c2404
<     color: @theme_base_color;

---
>     color: @text_color;
./MediterraneanNight/gtk-3.0/gtk-widgets.css
./MediterraneanDark/gtk-3.0/gtk-widgets.css
2404c2404
<     color: @theme_base_color;

---
>     color: @text_color;
./MediterraneanDarkest/gtk-3.0/gtk-widgets.css
2404c2404
<     color: @theme_base_color;

---
>     color: @fg_color;
./MediterraneanLight/gtk-3.0/gtk-widgets.css
./MediterraneanNightDarkest/gtk-3.0/gtk-widgets.css
./MediterraneanWhite/gtk-3.0/gtk-widgets.css
2404c2404
<     color: @theme_base_color;

---
>     color: @text_color;
./MediterraneanWhiteNight/gtk-3.0/gtk-widgets.css
2404c2404
<     color: @theme_base_color;

---
>     color: @text_color;
./MediterraneanTributeBlue/gtk-3.0/gtk-widgets.css
```

This means, these files are almost identical! :smile_cat:
I'll try to remove the differences completely later.
